### PR TITLE
Fix Shared-memory access counting

### DIFF
--- a/SConstruct1
+++ b/SConstruct1
@@ -175,6 +175,7 @@ run_directory("armada-parser", [
     ("test4", ["SharedStructs4", "D"], []),
     ("test5", ["SharedStructs5", "E"], []),
     ("test6", ["SharedStructs6", "F"], []),
+    ("test7", ["SharedStructs7", "G"], [])
 ])
 
 run_directory("mcslock", [

--- a/Test/armada-parser/test7.arm
+++ b/Test/armada-parser/test7.arm
@@ -1,0 +1,25 @@
+include "../../Armada/ArmadaCommonDefinitions.dfy"
+
+structs SharedStructs7 {}
+
+level {:concrete} G using SharedStructs7 {
+  var a: int64;
+  var b: int64;
+
+  var p: ptr<int64>;
+
+  method foobar(v: int64) returns (x: int64) {
+    x := 0;
+  }
+
+  method main() {
+    noaddr var c: int64;
+
+    *(&a + 4) := 0;
+    c := *(&a);
+    p := &a;
+
+    a, c := 1, 1;
+    a := foobar(b);
+  }
+}


### PR DESCRIPTION
This pull request should fix issue #14. The new algorithm for counting shared-memory access can be summarized as follows,

1. +1 whenever GetLValue in ResolveAsLValue
2. +1 whenver GetRValue in ResolveAsRValue
3. +1 whenver UnaryOp.Dereference in ResolveAsRValue
4. Resolution of LValue caused by UnaryOp.AddressOf doesn't count as a memory reference. This is dealt after the recursion.

In addition, the shared-memory access counting for method call arguments are separate from the rest of the statement. The reasoning is that a method call is translated into two separate next routines for call and return.