### PR TITLE
Bump to nightly F* version

### DIFF
--- a/experimental/docker/Dockerfile
+++ b/experimental/docker/Dockerfile
@@ -40,9 +40,8 @@ ENV PATH=${PATH}:$DOTNET_ROOT:$DOTNET_ROOT/tools
 ADD --chown=opam:opam https://github.com/tahina-pro/z3/releases/download/z3-4.8.5-linux-clang/z3-4.8.5-linux-clang-x86_64.tar.gz z3.tar.gz
 RUN tar xf z3.tar.gz
 
-RUN git clone https://github.com/FStarLang/FStar.git
+RUN git clone https://github.com/FStarLang/FStar.git -b v2024.01.13
 WORKDIR FStar/ 
-RUN git checkout v2023.04.08
 RUN eval $(opam env) && env OTHERFLAGS='--admit_smt_queries true' PATH=$HOME/z3:$PATH make -j $CI_THREADS 
 ENV PATH=${PATH}:/home/opam/FStar/bin:/home/opam/z3
 

--- a/experimental/fstar.opam
+++ b/experimental/fstar.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "2023.04.15~dev"
+version: "2024.01.13~dev"
 maintainer: "taramana@microsoft.com"
 authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.com>,Tahina Ramananandro <taramana@microsoft.com>"
 homepage: "http://fstar-lang.org"
@@ -11,6 +11,7 @@ depends: [
   "stdint"
   "yojson"
   "dune" {build & >= "3.2.0"}
+  "memtrace"
   "menhirLib"
   "menhir" {build & >= "2.1"}
   "pprint"
@@ -19,7 +20,7 @@ depends: [
   "process"
   "ppx_deriving" {build}
   "ppx_deriving_yojson" {build}
-  "z3" {= "4.8.5"}
+  "z3" {= "4.8.5-1"}
 ]
 depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
 build: [

--- a/experimental/lib/GlobalVarExampleInvariant.fst
+++ b/experimental/lib/GlobalVarExampleInvariant.fst
@@ -67,9 +67,9 @@ private let atomic_lprog_init_establishes_inductive_my_inv
   let initializer5: initializer_t =
     { var_id = "f"; iv = InitializerSpecific (ObjectValueAbstract int 1); weakly_consistent = false; } in
   assert (contains_ubool initializer5 MyLProg.prog.global_initializers)
-    by FStar.Tactics.norm [delta];
+    by FStar.Tactics.V2.norm [delta];
   assert (global_variables_unaddressed_in_initializers vs MyLProg.prog.global_initializers)
-    by (FStar.Tactics.compute (); FStar.Tactics.trivial ());
+    by (FStar.Tactics.V2.compute (); FStar.Tactics.V2.trivial ());
   init_implies_global_variables_unaddressed_in_memory vs MyLProg.prog s;
   assert (global_variables_unaddressed_in_memory vs s.mem)
 
@@ -165,5 +165,5 @@ let my_inv_is_stepwise_invariant ()
              MyAtomicLProg.prog inductive_my_inv) =
   let aiw = inductive_my_inv_witness () in
   assert (armada_atomic_semantics_invariant_witness_valid MyAtomicLProg.prog inductive_my_inv aiw)
-    by (FStar.Tactics.compute (); FStar.Tactics.trivial ());
+    by (FStar.Tactics.V2.compute (); FStar.Tactics.V2.trivial ());
   armada_atomic_semantics_invariant_witness_valid_implies_stepwise_invariant MyAtomicLProg.prog inductive_my_inv aiw

--- a/experimental/lib/Makefile
+++ b/experimental/lib/Makefile
@@ -8,7 +8,7 @@ FSTAR_EXEC?=$(shell which fstar.exe)
 Z3_EXEC?=$(shell which z3)
 
 ################################################################################
-FSTAR=$(FSTAR_EXEC) --cache_checked_modules --smt $(Z3_EXEC)
+FSTAR=$(FSTAR_EXEC) $(OTHERFLAGS) --cache_checked_modules --smt $(Z3_EXEC)
 
 all: verify-all
 

--- a/experimental/lib/MyAtomicBInvariant.fst
+++ b/experimental/lib/MyAtomicBInvariant.fst
@@ -130,5 +130,5 @@ let inv_is_stepwise_invariant ()
   : Lemma (is_armada_substep_invariant MyAtomicBProg.prog inv) =
   let aiw = inv_witness () in
   assert (armada_atomic_substep_invariant_witness_valid MyAtomicBProg.prog inv aiw)
-    by (FStar.Tactics.compute(); FStar.Tactics.trivial ());
+    by (FStar.Tactics.V2.compute(); FStar.Tactics.V2.trivial ());
   armada_atomic_substep_invariant_witness_valid_implies_is_substep_invariant MyAtomicBProg.prog inv aiw

--- a/experimental/lib/MyAtomicToRegularRefinement.fst
+++ b/experimental/lib/MyAtomicToRegularRefinement.fst
@@ -7,7 +7,7 @@ open Armada.Program
 open Armada.State
 open Armada.Statement
 open Armada.Type
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.Behavior
 open Spec.List
 open Spec.Ubool

--- a/experimental/lib/MyList.fst
+++ b/experimental/lib/MyList.fst
@@ -10,7 +10,7 @@ let my_fast_index_internal (n:nat{n < 1000}) : int = if n < 500 then (if n < 250
 let my_fast_index_internal_is_index ()
   : Lemma (length my_list = 1000 /\ equivalent_to_index my_list my_fast_index_internal) =
   assert (length my_list = 1000 /\ equivalent_to_index my_list my_fast_index_internal)
-    by FStar.Tactics.norm [zeta; delta; iota; primops]
+    by FStar.Tactics.V2.norm [zeta; delta; iota; primops]
 
 let my_fast_index (n:nat{n < 1000}) : (result:int{n < length my_list /\ index my_list n = result}) =
   my_fast_index_internal_is_index ();

--- a/experimental/lib/MyProgramInvariant.fst
+++ b/experimental/lib/MyProgramInvariant.fst
@@ -38,11 +38,11 @@ private let atomic_lprog_init_establishes_my_inv
   let initializer5: initializer_t =
     { var_id = "f"; iv = InitializerSpecific (ObjectValueAbstract int 1); weakly_consistent = false; } in
   assert (contains_ubool initializer5 MyLProg.prog.global_initializers)
-    by FStar.Tactics.norm [delta];
+    by FStar.Tactics.V2.norm [delta];
   let initializer6: initializer_t =
     { var_id = "g"; iv = InitializerSpecific (ObjectValueAbstract int 1); weakly_consistent = false; } in
   assert (contains_ubool initializer6 MyLProg.prog.global_initializers)
-    by FStar.Tactics.norm [delta];
+    by FStar.Tactics.V2.norm [delta];
   ()
 
 #pop-options
@@ -134,5 +134,5 @@ let my_inv_is_stepwise_invariant ()
              MyAtomicLProg.prog my_inv) =
   let aiw = my_inv_witness () in
   assert (armada_atomic_semantics_invariant_witness_valid MyAtomicLProg.prog my_inv aiw)
-    by (FStar.Tactics.compute (); FStar.Tactics.trivial ());
+    by (FStar.Tactics.V2.compute (); FStar.Tactics.V2.trivial ());
   armada_atomic_semantics_invariant_witness_valid_implies_stepwise_invariant MyAtomicLProg.prog my_inv aiw

--- a/experimental/lib/MyProgramProof.fst
+++ b/experimental/lib/MyProgramProof.fst
@@ -9,7 +9,7 @@ open Armada.Statement
 open Armada.Transition
 open Armada.Type
 open FStar.List.Tot.Base
-open FStar.Tactics
+open FStar.Tactics.V2
 open MyAtomicToRegularRefinement
 open MyProgramInvariant
 open MyRegularToAtomicRefinement

--- a/experimental/lib/MyRegularToAtomicRefinement.fst
+++ b/experimental/lib/MyRegularToAtomicRefinement.fst
@@ -9,7 +9,7 @@ open Armada.State
 open Armada.Statement
 open Armada.Thread
 open Armada.Type
-open FStar.Tactics
+open FStar.Tactics.V2
 open MyAtomicLProg
 open MyLProg
 open Spec.Behavior

--- a/experimental/lib/MyVarHidingProof.fst
+++ b/experimental/lib/MyVarHidingProof.fst
@@ -537,6 +537,6 @@ let lemma_MyAtomicAProgRefinesMyAtomicBProg ()
   let pc_relation = efficient_lh_pc_relation lpc_to_hpc in
   let pc_return_relation = efficient_lh_pc_return_relation lpc_to_hpc is_return_lpc in
   assert (efficient_var_hiding_witness_valid latomic_prog hatomic_prog vw)
-    by (FStar.Tactics.compute (); FStar.Tactics.trivial ());
+    by (FStar.Tactics.V2.compute (); FStar.Tactics.V2.trivial ());
   MyAtomicBInvariant.inv_is_stepwise_invariant ();
   efficient_var_hiding_witness_valid_implies_refinement latomic_prog hatomic_prog vw

--- a/experimental/lib/MyVarIntroProof.fst
+++ b/experimental/lib/MyVarIntroProof.fst
@@ -566,6 +566,6 @@ let lemma_MyAtomicAProgRefinesMyAtomicBProg ()
   let latomic_prog = MyAtomicAProg.prog in
   let hatomic_prog = MyAtomicBProg.prog in
   assert (efficient_var_intro_witness_valid latomic_prog hatomic_prog vw)
-    by (FStar.Tactics.compute (); FStar.Tactics.trivial ());
+    by (FStar.Tactics.V2.compute (); FStar.Tactics.V2.trivial ());
   MyAtomicBInvariant.inv_is_stepwise_invariant ();
   efficient_var_intro_witness_valid_implies_refinement latomic_prog hatomic_prog vw

--- a/experimental/lib/Strategies.ArmadaInvariant.PositionsValid.fst
+++ b/experimental/lib/Strategies.ArmadaInvariant.PositionsValid.fst
@@ -16,7 +16,7 @@ open Armada.Transition
 open Armada.Type
 open FStar.Sequence.Ambient
 open FStar.Sequence.Base
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.List
 open Spec.Ubool
 open Strategies.ArmadaStatement

--- a/experimental/lib/Strategies.ArmadaInvariant.RootsMatch.fst
+++ b/experimental/lib/Strategies.ArmadaInvariant.RootsMatch.fst
@@ -14,7 +14,7 @@ open Armada.Thread
 open Armada.Transition
 open Armada.Type
 open FStar.Sequence.Base
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.List
 open Spec.Map
 open Spec.Ubool

--- a/experimental/lib/Strategies.ArmadaStatement.Opaque.fst
+++ b/experimental/lib/Strategies.ArmadaStatement.Opaque.fst
@@ -14,7 +14,7 @@ open Armada.Thread
 open Armada.Type
 open Armada.UnaryOp
 open FStar.Sequence.Base
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.List
 open Spec.Ubool
 open Util.List

--- a/experimental/lib/Strategies.ArmadaStatement.ThreadState.fst
+++ b/experimental/lib/Strategies.ArmadaStatement.ThreadState.fst
@@ -12,7 +12,7 @@ open Armada.Statement
 open Armada.Thread
 open Armada.Transition
 open Armada.Type
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.List
 open Spec.Logic
 open Spec.Ubool

--- a/experimental/lib/Strategies.AtomicToRegular.Armada.fst
+++ b/experimental/lib/Strategies.AtomicToRegular.Armada.fst
@@ -55,12 +55,12 @@ let atomic_refines_armada_relation_implies_valid_atomic_to_regular_map
   aa.atomic_to_regular_map_valid ();
   assert (valid_atomic_to_armada_map atomic_actions aa.atomic_to_regular_map aa.actions_array ==
            lists_correspond_ubool indices_and_actions_corr aa.atomic_to_regular_map atomic_actions)
-    by FStar.Tactics.trefl();
+    by FStar.Tactics.V2.trefl();
   lists_correspond_ubool_implies_weaker_correspondence
     indices_and_actions_corr indices_and_actions_corr' aa.atomic_to_regular_map atomic_actions lem2;
   assert (valid_atomic_to_regular_map armada_semantics atomic_actions regular_actions aa.atomic_to_regular_map ==
            lists_correspond_ubool indices_and_actions_corr' aa.atomic_to_regular_map atomic_actions)
-    by FStar.Tactics.trefl()
+    by FStar.Tactics.V2.trefl()
 
 let atomic_refines_armada_relation_implies_refinement (aa: atomic_refines_armada_relation_t)
   : Lemma (ensures (spec_refines_spec

--- a/experimental/lib/Strategies.AtomicToRegular.fst
+++ b/experimental/lib/Strategies.AtomicToRegular.fst
@@ -198,7 +198,7 @@ let expanding_atomic_action_preserves_program_containment
   ar.atomic_to_regular_map_valid ();
   assert (valid_atomic_to_regular_map sem atomic_actions regular_actions ar.atomic_to_regular_map ==
           lists_correspond_ubool indices_and_actions_corr ar.atomic_to_regular_map atomic_actions)
-    by FStar.Tactics.trefl ();
+    by FStar.Tactics.V2.trefl ();
   lists_correspond_ubool_implies_index_matches
     indices_and_actions_corr ar.atomic_to_regular_map atomic_actions atomic_index;
   let indices = Some?.v (nth ar.atomic_to_regular_map atomic_index) in
@@ -247,7 +247,7 @@ let atomic_refines_regular_relation_implies_spec_next
     let lactions = map_ghost (map_ghost sem.step_to_action_f) lsteps in
     let property1 = fun atomic_step -> contains_ubool (map_ghost sem.step_to_action_f atomic_step) atomic_actions in
     assert (for_all_ubool (program_contains_action_of_step_generic atomic_sem ar.lprog) lsteps);
-    assert (program_contains_action_of_step_generic atomic_sem ar.lprog == property1) by FStar.Tactics.trefl();
+    assert (program_contains_action_of_step_generic atomic_sem ar.lprog == property1) by FStar.Tactics.V2.trefl();
     assert (for_all_ubool property1 lsteps);
     let property2 = fun atomic_action -> contains_ubool atomic_action atomic_actions in
     for_all_ubool_map

--- a/experimental/lib/Strategies.GlobalVars.Permanent.fst
+++ b/experimental/lib/Strategies.GlobalVars.Permanent.fst
@@ -14,7 +14,7 @@ open Armada.Thread
 open Armada.Transition
 open Armada.Type
 open FStar.Sequence.Base
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.List
 open Spec.Map
 open Spec.Ubool

--- a/experimental/lib/Strategies.GlobalVars.Types.fst
+++ b/experimental/lib/Strategies.GlobalVars.Types.fst
@@ -14,7 +14,7 @@ open Armada.Thread
 open Armada.Transition
 open Armada.Type
 open FStar.Sequence.Base
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.List
 open Spec.Map
 open Spec.Ubool

--- a/experimental/lib/Strategies.Invariant.fst
+++ b/experimental/lib/Strategies.Invariant.fst
@@ -105,7 +105,7 @@ let step_computation_generic_preserves_inv
   | None ->
       assert (action_proof_option_applies sip.sem sip.inv sip.action_pred action None ==
               sip.action_pred action)
-        by FStar.Tactics.trefl();
+        by FStar.Tactics.V2.trefl();
     step_computation_generic_preserves_inv_case_action_pred sip actor starts_atomic_block ends_atomic_block step s
   | Some prf -> step_computation_generic_preserves_inv_case_special_case sip actor
                  starts_atomic_block ends_atomic_block step s prf

--- a/experimental/lib/Strategies.VarHiding.Helpers.fst
+++ b/experimental/lib/Strategies.VarHiding.Helpers.fst
@@ -131,6 +131,7 @@ let rec lsteps_correspond_to_hsteps
            hstart_state lend_state hend_state remaining_which_actions_hidden remaining_lsteps hsteps
   | _, _, _ -> False
 
+#push-options "--split_queries always"
 let rec compute_hsteps_from_lsteps
   (vs: list var_id_t)
   (lpc_to_hpc: pc_t -> GTot pc_t)
@@ -178,6 +179,7 @@ let rec compute_hsteps_from_lsteps
                 which_actions_hidden lsteps hsteps);
       hsteps
   | _, _, _, _ -> false_elim ()
+#pop-options
 
 let lstep_corresponds_to_hstep_clarifier
   (vs: list var_id_t)

--- a/experimental/lib/Strategies.Weakening.Armada.fst
+++ b/experimental/lib/Strategies.Weakening.Armada.fst
@@ -7,7 +7,7 @@ open Armada.Step
 open Armada.Transition
 open Armada.Type
 open FStar.List.Tot
-open FStar.Tactics
+open FStar.Tactics.V2
 open Spec.Behavior
 open Strategies.Atomic
 open Strategies.Invariant

--- a/experimental/lib/Util.Tactics.fst
+++ b/experimental/lib/Util.Tactics.fst
@@ -1,7 +1,8 @@
 module Util.Tactics
 
 open FStar.Printf
-open FStar.Tactics
+open FStar.Tactics.V2
+open FStar.Reflection.V2.TermEq
 
 /// Replacing a function in the current goal
 ///
@@ -130,6 +131,7 @@ let rec fn_to_lemma_invocations_in_term (fn: term) (argc: pos) (lem: term) (t: t
   | Tv_AscribedC e _ _ _ ->
       fn_to_lemma_invocations_in_term fn argc lem e
   | Tv_Unknown -> None
+  | Tv_Unsupp -> None
 
 and fn_to_lemma_invocations_in_branches
   (fn: term)
@@ -202,7 +204,7 @@ let rec identifier_to_string (id: list string) : Tac string =
 
 let rec term_to_view_to_string (t: term) : Tac string =
   match inspect t with
-  | Tv_Var v -> "Tv_Var " ^ (bv_to_string v)
+  | Tv_Var v -> "Tv_Var " ^ (namedv_to_string v)
   | Tv_BVar v -> "Tv_BVar " ^ (bv_to_string v)
   | Tv_FVar v -> "Tv_FVar " ^ (fv_to_string v)
   | Tv_UInst v us -> "Tv_UInst " ^ (fv_to_string v)
@@ -215,13 +217,14 @@ let rec term_to_view_to_string (t: term) : Tac string =
   | Tv_Const v -> "Tv_Const(" ^ (vconst_to_string v) ^ ")"
   | Tv_Uvar _ _ -> "Tv_Uvar"
   | Tv_Let recf attrs bv def body ->
-      "Tv_Let(" ^ (term_to_view_to_string (bv_to_term bv)) ^
+      "Tv_Let(" ^ (term_to_view_to_string (binder_to_term bv)) ^
               " = " ^ (term_to_view_to_string def) ^ " in " ^ (term_to_view_to_string body) ^ ")"
   | Tv_Match scrutinee ret brs ->
      "Tv_Match(" ^ (term_to_view_to_string scrutinee) ^ " with " ^ (branches_to_string brs) ^ ")"
   | Tv_AscribedT e t tac _ -> "Tv_AscribedT(" ^ (term_to_view_to_string e) ^ ")"
   | Tv_AscribedC e c tac _ -> "Tv_AscribedC(" ^ (term_to_view_to_string e) ^ ")"
   | Tv_Unknown -> "Tv_Unknown"
+  | Tv_Unsupp -> "Tv_Unsupp"
 
 and term_views_to_strings (ts: list term) : Tac string =
   match ts with


### PR DESCRIPTION
For our upcoming F* dataset, we want to build all F* projects with the same, nightly F* version.  This PR makes the changes necessary to build with the latest and greatest F*.

Some of the tests still fail however, e.g. Z3 fails to show that the invariant is preserved in `invariantDecl_MaintainedIfStmtSatisfies`.